### PR TITLE
CLI script output should not include 'json_data' key

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 Call `libcovebods` and pass the filename of some JSON data.
 
     libcovebods tests/fixtures/0.1/basic_1.json
+    
+You can also pass the raw option to see the JSON as it originally came out of the library.
+
+    libcovebods --raw tests/fixtures/0.1/basic_1.json
 
 ## Code for use by external users
 

--- a/libcovebods/cli/__main__.py
+++ b/libcovebods/cli/__main__.py
@@ -8,6 +8,7 @@ import json
 def main():
     parser = argparse.ArgumentParser(description='Lib Cove BODS CLI')
     parser.add_argument("filename")
+    parser.add_argument("--raw", help="show raw output from the library", action="store_true")
 
     args = parser.parse_args()
 
@@ -20,6 +21,9 @@ def main():
         )
     finally:
         shutil.rmtree(cove_temp_folder)
+
+    if not args.raw:
+        del result['json_data']
 
     print(json.dumps(result, indent=4))
 


### PR DESCRIPTION
Unless you pass the new "raw" option
https://github.com/openownership/lib-cove-bods/issues/18