### PR TITLE
Upgrade Django to 2.2.4 for security fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ certifi==2019.3.9
 chardet==3.0.4
 commonmark==0.8.1
 contextlib2==0.5.5
-Django==2.2
+Django==2.2.4
 et-xmlfile==1.0.1
 future==0.17.1
 idna==2.8

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,7 @@ certifi==2019.3.9
 chardet==3.0.4
 commonmark==0.8.1
 contextlib2==0.5.5
-Django==2.2
+Django==2.2.4
 entrypoints==0.3
 et-xmlfile==1.0.1
 future==0.17.1


### PR DESCRIPTION
Github was bugging me while working on #40 and whilst I don't think there's any real security risk from it (presumably any including project sets its own Django version and is more on top of any version bumps) - it's nice to reduce noise so we can see any real issues.