### PR TITLE
Removing out of date schema editing guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ you have checked out:
 
     compiletojsonschema -c openownership-data-standard/schema/codelists/ openownership-data-standard/schema/bods-package.json > openownership-lib-cove-bods/libcovebods/data/schema-0-2-0.json  
 
+Due to https://github.com/openownership/data-standard/issues/375 you may have to do some editing by hand when using early versions of the schema, pre 0.3. Open the files in `libcovebods/data`. At the top level there is an `oneOf` with 3 statement types - people, entity, and ownershipOrControl. In each of these statement types, there is an enum for the `statementType` field. This enum should have one option only - the value for whatever type of statement it is. (ie The person statement should only have the `personStatement` value). This tool may have added extra options - if so, remove them by hand.
+
 ## Code for use by external users
 
 The only code that should be used directly by users is the `libcovebods.config` and `libcovebods.api` modules.

--- a/README.md
+++ b/README.md
@@ -44,13 +44,7 @@ ie. To update the `libcovebods/data/schema-0-2-0.json` file, check out `0.2.0`
 Run the compile tool, telling it where the codelists directory is and pipe the output to the file for the version 
 you have checked out:
 
-    compiletojsonschema -c openownership-data-standard/schema/codelists/ openownership-data-standard/schema/bods-package.json > openownership-lib-cove-bods/libcovebods/data/schema-0-2-0.json 
-
-Due to https://github.com/openownership/data-standard/issues/375 you may have to do some editing by hand. Open the files 
-in `libcovebods/data`. At the top level there is an `oneOf` with 3 statement types - people, entity, and ownershipOrControl.
-In each of these statement types, there is an enum for the `statementType` field. This enum should have one option only - 
-the value for whatever type of statement it is. (ie The person statement should only have the `personStatement` value) 
-This tool may have added extra options - if so, remove them by hand. 
+    compiletojsonschema -c openownership-data-standard/schema/codelists/ openownership-data-standard/schema/bods-package.json > openownership-lib-cove-bods/libcovebods/data/schema-0-2-0.json  
 
 ## Code for use by external users
 


### PR DESCRIPTION
It's because this issue (https://github.com/openownership/data-standard/issues/375) has been resolved, I think, that Emma and I didn't need to make any of the edits mentioned in the ReadMe. In which case the ReadMe text can be edited as per this PR.

Assigning to @odscjames for review, who'll know if that's right. 